### PR TITLE
Prevent OS passwords from being displayed during kitchen create

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ This will use chef-zero and needs no chef server (only works for ssh). Note that
 - `[:customization_spec][:hostname]` - hostname to use. Defaults to machine resource name if not provided
 - `[:customization_spec][:org_name]` - org name used in sysprep on windows
 - `[:customization_spec][:product_id]` - windows product key
-- `[:customization_spec][:run_once]` - commands for vSphere to run at the end of windows bootstrapping; set this to your own array to override the [default winrm setup options](http://www.rubydoc.info/gems/chef-provisioning-vsphere/ChefProvisioningVsphere%2FHelpers%3Awindows_prep_for)
+- `[:customization_spec][:run_once]` - Array of commands for vSphere to run at the end of windows bootstrapping
 - `[:customization_spec][:time_zone]` - The case-sensitive timezone, such as Europe/Sofia based on the tz (timezone) database used by Linux and other Unix systems
-- `[:customization_spec][:transport]` - winrm transport to use. Defaults to `plaintext`
+- `[:customization_spec][:winrm_transport]` - winrm transport to use. Defaults to `negotiate`
 - `[:customization_spec][:win_time_zone]` - numeric time zone for windows
 - `[:customization_spec][:winrm_opts]` - Optional hash of [winrm options](https://github.com/WinRb/WinRM) (e.g. `disable_sspi: true`)
 

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ end
 This chef-provisioning-driver comes with a test-kitchen driver. Here are example driver options you can add to your `kitchen.yml`.
 
 ```
-driver_plugin: vsphere
-driver_config:
+driver:
+  name: vsphere
   driver_options:
     host: '1.2.3.5'
     user: 'user'

--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ This will use chef-zero and needs no chef server (only works for ssh). Note that
 - `[:customization_spec][:hostname]` - hostname to use. Defaults to machine resource name if not provided
 - `[:customization_spec][:org_name]` - org name used in sysprep on windows
 - `[:customization_spec][:product_id]` - windows product key
+- `[:customization_spec][:run_once]` - commands for vSphere to run at the end of windows bootstrapping; set this to your own array to override the [default winrm setup options](http://www.rubydoc.info/gems/chef-provisioning-vsphere/ChefProvisioningVsphere%2FHelpers%3Awindows_prep_for)
 - `[:customization_spec][:time_zone]` - The case-sensitive timezone, such as Europe/Sofia based on the tz (timezone) database used by Linux and other Unix systems
+- `[:customization_spec][:transport]` - winrm transport to use. Defaults to `plaintext`
 - `[:customization_spec][:win_time_zone]` - numeric time zone for windows
+- `[:customization_spec][:winrm_opts]` - Optional hash of [winrm options](https://github.com/WinRb/WinRM) (e.g. `disable_sspi: true`)
 
 ## Timeout options
 These are settings set at the root of `machine_options`. Chances are the defaults for these settings do not need to be changed:

--- a/chef-provisioning-vsphere.gemspec
+++ b/chef-provisioning-vsphere.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rbvmomi', '~> 1.8.0', '>= 1.8.2'
   s.add_dependency 'chef-provisioning', '~>1.1'
+  s.add_dependency 'winrm', '~> 1.6'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
+++ b/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
@@ -160,22 +160,8 @@ module ChefProvisioningVsphere
 
     def windows_prep_for(options, vm_name)
       cust_options = options[:customization_spec]
-      Chef::Log.warn('Using default insecure WinRM setup commands') if
-        cust_options[:run_once].nil?
-      command_list =
-        case cust_options[:run_once].nil?
-        when true
-          [
-            'winrm set winrm/config/client/auth @{Basic="true"}',
-            'winrm set winrm/config/service/auth @{Basic="true"}',
-            'winrm set winrm/config/service @{AllowUnencrypted="true"}',
-            'shutdown -l'
-          ]
-        else
-          cust_options[:run_once]
-        end
       cust_runonce = RbVmomi::VIM::CustomizationGuiRunOnce.new(
-        :commandList => command_list)
+        :commandList => cust_options[:run_once]) unless cust_options[:run_once].nil?
 
       cust_login_password = RbVmomi::VIM::CustomizationPassword(
         :plainText => true,

--- a/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
+++ b/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
@@ -160,6 +160,8 @@ module ChefProvisioningVsphere
 
     def windows_prep_for(options, vm_name)
       cust_options = options[:customization_spec]
+      Chef::Log.warn('Using default insecure WinRM setup commands') if
+        cust_options[:run_once].nil?
       command_list =
         case cust_options[:run_once].nil?
         when true

--- a/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
+++ b/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
@@ -160,12 +160,20 @@ module ChefProvisioningVsphere
 
     def windows_prep_for(options, vm_name)
       cust_options = options[:customization_spec]
+      command_list =
+        case cust_options[:run_once].nil?
+        when true
+          [
+            'winrm set winrm/config/client/auth @{Basic="true"}',
+            'winrm set winrm/config/service/auth @{Basic="true"}',
+            'winrm set winrm/config/service @{AllowUnencrypted="true"}',
+            'shutdown -l'
+          ]
+        else
+          cust_options[:run_once]
+        end
       cust_runonce = RbVmomi::VIM::CustomizationGuiRunOnce.new(
-        :commandList => [
-          'winrm set winrm/config/client/auth @{Basic="true"}',
-          'winrm set winrm/config/service/auth @{Basic="true"}',
-          'winrm set winrm/config/service @{AllowUnencrypted="true"}',
-          'shutdown -l'])
+        :commandList => command_list)
 
       cust_login_password = RbVmomi::VIM::CustomizationPassword(
         :plainText => true,

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -641,9 +641,9 @@ module ChefProvisioningVsphere
 
     def create_winrm_transport(host, options)
       require 'chef/provisioning/transport/winrm'
-      port = options[:port].nil? ? '5985' : options[:port]
       winrm_transport =
-        options[:transport].nil? ? :plaintext : options[:transport].to_sym
+        options[:winrm_transport].nil? ? :negotiate : options[:winrm_transport].to_sym
+      port = options[:port] || winrm_transport == :ssl ? '5986' : '5985'
       winrm_options = {
         user: "#{options[:user]}",
         pass: options[:password]

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -662,7 +662,7 @@ module ChefProvisioningVsphere
       Chef::Provisioning::Transport::SSH.new(
         host,
         ssh_user,
-        options,
+        options.to_hash,
         @config[:machine_options][:sudo] ? {:prefix => 'sudo '} : {},
         config
       )

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -360,7 +360,7 @@ module ChefProvisioningVsphere
           connectable = transport_for(
             machine_spec,
             machine_options[:bootstrap_options][:ssh],
-            ip
+            vm_ip
           ).available?
         end
         sleep 5

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -304,7 +304,7 @@ module ChefProvisioningVsphere
     def attempt_ip(machine_options, action_handler, vm, machine_spec)
       vm_ip = ip_to_bootstrap(machine_options[:bootstrap_options], vm)
       
-      wait_for_ip(vm, machine_options, action_handler)
+      wait_for_ip(vm, machine_options, machine_spec, action_handler)
 
       unless has_ip?(vm_ip, vm)
         action_handler.report_progress "rebooting..."
@@ -319,7 +319,7 @@ module ChefProvisioningVsphere
         else
           restart_server(action_handler, machine_spec, machine_options)
         end
-        wait_for_ip(vm, machine_options, action_handler)
+        wait_for_ip(vm, machine_options, machine_spec, action_handler)
       end
     end
 
@@ -342,7 +342,7 @@ module ChefProvisioningVsphere
       end
     end
 
-    def wait_for_ip(vm, machine_options, action_handler)
+    def wait_for_ip(vm, machine_options, machine_spec, action_handler)
       bootstrap_options = machine_options[:bootstrap_options]
       vm_ip = ip_to_bootstrap(bootstrap_options, vm)
       ready_timeout = machine_options[:ready_timeout] || 300
@@ -351,10 +351,18 @@ module ChefProvisioningVsphere
       action_handler.report_progress msg
 
       start = Time.now.utc
-      until (Time.now.utc - start) > ready_timeout || has_ip?(vm_ip, vm) do
+      connectable = false
+      until (Time.now.utc - start) > ready_timeout || connectable do
         action_handler.report_progress(
           "IP addresses found: #{all_ips_for(vm)}")
         vm_ip ||= ip_to_bootstrap(bootstrap_options, vm)
+        if has_ip?(vm_ip, vm)
+          connectable = transport_for(
+            machine_spec,
+            machine_options[:bootstrap_options][:ssh],
+            ip
+          ).available?
+        end
         sleep 5
       end
     end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.2'
+  VERSION = '0.8.3.dev'
 end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.3.dev'
+  VERSION = '0.8.3.dev.2'
 end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.3.dev.2'
+  VERSION = '0.8.3'
 end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.4'
+  VERSION = '0.9.0'
 end

--- a/lib/chef/provisioning/vsphere_driver/version.rb
+++ b/lib/chef/provisioning/vsphere_driver/version.rb
@@ -1,3 +1,3 @@
 module ChefProvisioningVsphere
-  VERSION = '0.8.3'
+  VERSION = '0.8.4'
 end

--- a/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
+++ b/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
@@ -17,6 +17,7 @@ module ChefProvisioningVsphere
 
     def vim
       if @current_connection.nil? or @current_connection.serviceContent.sessionManager.currentSession.nil?
+        @datacenter = nil
         puts "establishing connection to #{connect_options[:host]}"
         @current_connection = RbVmomi::VIM.connect connect_options
         str_conn = @current_connection.pretty_inspect # a string in the format of VIM(host ip)
@@ -81,6 +82,7 @@ module ChefProvisioningVsphere
     end
 
     def datacenter
+      vim # ensure connection is valid
       @datacenter ||= vim.serviceInstance.find_datacenter(datacenter_name) ||
         raise("vSphere Datacenter not found [#{datacenter_name}]")
     end

--- a/spec/integration_tests/vsphere_driver_spec.rb
+++ b/spec/integration_tests/vsphere_driver_spec.rb
@@ -94,7 +94,7 @@ describe 'vsphere_driver' do
     end
     it 'is in the correct host' do
       if @metal_config[:machine_options][:bootstrap_options].has_key?(:host)
-        expect(@vm.runtime.host.name).to eq(@metal_config[:machine_options][:bootstrap_options][:host].split('/')[1])
+        expect(@vm.runtime.host.name).to eq(@metal_config[:machine_options][:bootstrap_options][:host].split('/').last)
       end
     end
     it 'is in the correct cluster' do


### PR DESCRIPTION
Currently OS passwords are displayed on kitchen create, this is a problem even if it is a dev or lab environment 
